### PR TITLE
Add kicker job to keep the Repo alive

### DIFF
--- a/.github/workflows/kicker-job.yml
+++ b/.github/workflows/kicker-job.yml
@@ -8,22 +8,23 @@ on:
   workflow_dispatch:
   
 jobs:
-  runs-on: ubuntu-latest
-  steps:
-  - name: Checkout Repo
-    uses: actions/checkout@v4
-  
-  - name: Append new month
-    run: |
-      date +"Update %Y, Month %m" >> kickerlist.txt
+  kick-repo-to-be-alive:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
     
-  - name: Commit and push changes
-    run: |
-      git config user.name 'github-actions[bot]'
-      git config user.email 'github-actions[bot]@users.noreply.github.com'
+    - name: Append new month
+      run: |
+        date +"Update %Y, Month %m" >> kickerlist.txt
+      
+    - name: Commit and push changes
+      run: |
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
 
-      git add -A
-      git commit -m "Push new month"
-      git push
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        git add -A
+        git commit -m "Push new month"
+        git push
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/kicker-job.yml
+++ b/.github/workflows/kicker-job.yml
@@ -1,0 +1,29 @@
+name: Kicker Job to keep the Repository active
+
+on:
+  # workflow_dispatch is mandatory, so that Artifactory can trigger
+  # the workflow through GitHub REST API.
+  schedule:
+    - cron: '0 6 1 * *'
+  workflow_dispatch:
+  
+jobs:
+  runs-on: ubuntu-latest
+  steps:
+  - name: Checkout Repo
+    uses: actions/checkout@v4
+  
+  - name: Append new month
+    run: |
+      date +"Update %Y, Month %m" >> kickerlist.txt
+    
+  - name: Commit and push changes
+    run: |
+      git config user.name 'github-actions[bot]'
+      git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      git add -A
+      git commit -m "Push new month"
+      git push
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/kicker-job.yml
+++ b/.github/workflows/kicker-job.yml
@@ -3,10 +3,11 @@ name: Kicker Job to keep the Repository active
 on:
   # workflow_dispatch is mandatory, so that Artifactory can trigger
   # the workflow through GitHub REST API.
+  workflow_dispatch:
+
   schedule:
     - cron: '0 6 1 * *'
-  workflow_dispatch:
-  
+
 jobs:
   kick-repo-to-be-alive:
     runs-on: ubuntu-latest

--- a/kickerlist.txt
+++ b/kickerlist.txt
@@ -1,0 +1,1 @@
+This list is used to keep the repo alive and the bot running.


### PR DESCRIPTION
Adds a GH action job that runs automatically once a month and commits to a file to keep the repo from becoming stale. If the repo becomes stale, the bot stops running and we won't know when delicious nuggets are available in the mensa :(